### PR TITLE
Fix importing of sitetree from 2.4 into 3.1

### DIFF
--- a/code/import/SilverStripeDataObjectImporter.php
+++ b/code/import/SilverStripeDataObjectImporter.php
@@ -26,6 +26,14 @@ class SilverStripeDataObjectImporter implements ExternalContentTransformer
 		$obj->Version = 1;
 		
 		if ($parentObject && $parentObject->hasExtension('Hierarchy')) {
+			if($cls == "SilverStripeContentItem" && $item->Title == "Files") {
+				$fakeId = '0-File';
+				$fakeFiles = new SilverStripeContentItem($item->source, $fakeId);
+				$fakeFiles->Title = 'Files';
+				$fakeFiles->ID = $item->ID . ExternalContent::ID_SEPARATOR . $fakeId;
+				return $fakeFiles;
+			}
+
 			$filter = '"Title" = \'' . Convert::raw2sql($item->Title) . '\' AND "ParentID" = ' . ((int) $parentObject->ID);
 			
 			$existing = DataObject::get_one($cls, $filter);
@@ -56,7 +64,7 @@ class SilverStripeDataObjectImporter implements ExternalContentTransformer
 		
 		$obj->write();
 		
-		if ($obj->hasExtension('Versioned') && $parentObject->isPublished()) {
+		if ($parentObject->ClassName != "Folder" && $obj->hasExtension('Versioned') && $parentObject->isPublished()) {
 			$obj->publish('Stage', 'Live');
 		}
 

--- a/code/remote/SilverStripeClient.php
+++ b/code/remote/SilverStripeClient.php
@@ -125,13 +125,14 @@ class DataObjectSetReturnHandler extends RemoteDataObjectHandler implements Retu
 		$objects = new ArrayList();
 		// lets get all the items beneath the root item
 		foreach ($xml->childNodes as $node) {
-			if ($node->nodeName == 'ArrayList') {
+			if ($node->nodeName == 'ArrayList' || $node->nodeName == 'DataObjectSet') {
 				foreach ($node->childNodes as $childNode) {
 					if ($childNode instanceof DOMText) {
 						continue;
 					}
 
-					$objects->push($this->getRemoteObject($childNode));
+					$remObj = $this->getRemoteObject($childNode);
+					$objects->push($remObj);
 				}
 			}
 		}


### PR DESCRIPTION
Adds in ability to read DataObjectSet elements in remote API for older 2.4 instances
Fix up files not being read/imported correctly due to assumed object type (hits ORM and invalid columns)
